### PR TITLE
Type-defined Identifiers + "Response" naming

### DIFF
--- a/Sources/UNogsAPI/Requests/API Client/UNogsAPIClient+Country.swift
+++ b/Sources/UNogsAPI/Requests/API Client/UNogsAPIClient+Country.swift
@@ -10,7 +10,7 @@ import Combine
 
 public extension UNogsAPIClient {
 
-    func countriesPublisher() -> AnyPublisher<ItemsResponse<Country>, Error> {
+    func countriesPublisher() -> AnyPublisher<ItemsResponse<CountryResponse>, Error> {
         return publisher(for: createGetRequest(queryItems: [
             URLQueryItem(name: "t", value: "lc"),
             URLQueryItem(name: "q", value: "available"),

--- a/Sources/UNogsAPI/Requests/API Client/UNogsAPIClient+Genre.swift
+++ b/Sources/UNogsAPI/Requests/API Client/UNogsAPIClient+Genre.swift
@@ -10,7 +10,7 @@ import Combine
 
 public extension UNogsAPIClient {
 
-    func genresPublisher() -> AnyPublisher<ItemsResponse<Genre>, Error> {
+    func genresPublisher() -> AnyPublisher<ItemsResponse<GenreResponse>, Error> {
         return publisher(for: createGetRequest(queryItems: [
             URLQueryItem(name: "t", value: "genres")
         ]))

--- a/Sources/UNogsAPI/Requests/API Client/UNogsAPIClient+NetflixTitle.swift
+++ b/Sources/UNogsAPI/Requests/API Client/UNogsAPIClient+NetflixTitle.swift
@@ -10,7 +10,7 @@ import Combine
 
 public extension UNogsAPIClient {
     
-    func newReleasesPublisher(countryShortCode: String) -> AnyPublisher<ItemsResponse<NetflixTitle>, Error>  {
+    func newReleasesPublisher(countryShortCode: String) -> AnyPublisher<ItemsResponse<TitleResponse>, Error>  {
         return publisher(for: createGetRequest(queryItems: [
             URLQueryItem(name: "p",     value: "1"),
             URLQueryItem(name: "q",     value: "get:new7:\(countryShortCode)"),
@@ -19,7 +19,7 @@ public extension UNogsAPIClient {
         ]))
     }
 
-    func expiringPublisher(countryShortCode: String) -> AnyPublisher<ItemsResponse<NetflixTitle>, Error>  {
+    func expiringPublisher(countryShortCode: String) -> AnyPublisher<ItemsResponse<TitleResponse>, Error>  {
         return publisher(for: createGetRequest(queryItems: [
             URLQueryItem(name: "p",     value: "1"),
             URLQueryItem(name: "q",     value: "get:exp:\(countryShortCode)"),
@@ -28,7 +28,7 @@ public extension UNogsAPIClient {
         ]))
     }
 
-    func filteredTitlesPublisher(query: FilteredTitlesQuery) -> AnyPublisher<ItemsResponse<NetflixTitle>, Error> {
+    func filteredTitlesPublisher(query: FilteredTitlesQuery) -> AnyPublisher<ItemsResponse<TitleResponse>, Error> {
         return publisher(for: createGetRequest(queryItems: [
             URLQueryItem(name: "q",     value: query.queryString),
             URLQueryItem(name: "t",     value: "ns"),

--- a/Sources/UNogsAPI/Requests/FilteredTitlesQuery/FilteredTitlesQuery.swift
+++ b/Sources/UNogsAPI/Requests/FilteredTitlesQuery/FilteredTitlesQuery.swift
@@ -16,7 +16,7 @@ public struct FilteredTitlesQuery {
     let subtitle: Subtitle
     let audio: Audio
     let videoType: VideoType
-    let genres: [Genre]
+    let genres: [GenreResponse]
     let minimumIMDBVotes: MinimumIMDBVotes
     let downloadable: Downloadable
     let countriesFilter: CountriesFilter
@@ -29,7 +29,7 @@ public struct FilteredTitlesQuery {
                 subtitle: Subtitle =                    .default,
                 audio: Audio =                          .default,
                 videoType: VideoType =                  .default,
-                genres: [Genre] =                       .default,
+                genres: [GenreResponse] =                       .default,
                 minimumIMDBVotes: MinimumIMDBVotes =    .default,
                 downloadable: Downloadable =            .default,
                 countriesFilter: CountriesFilter =      .default) {

--- a/Sources/UNogsAPI/Requests/FilteredTitlesQuery/Query Components/CountriesFilter.swift
+++ b/Sources/UNogsAPI/Requests/FilteredTitlesQuery/Query Components/CountriesFilter.swift
@@ -11,7 +11,7 @@ public enum CountriesFilter: QueryComponent, Defaultable {
     public static var `default` = CountriesFilter.all
 
     case all
-    case list(countryIds: [Country.CountryIdentifier])
+    case list(countryIds: [CountryResponse.CountryIdentifier])
 
     var stringValue: String {
         switch self {

--- a/Sources/UNogsAPI/Requests/FilteredTitlesQuery/Query Components/CountriesFilter.swift
+++ b/Sources/UNogsAPI/Requests/FilteredTitlesQuery/Query Components/CountriesFilter.swift
@@ -11,14 +11,14 @@ public enum CountriesFilter: QueryComponent, Defaultable {
     public static var `default` = CountriesFilter.all
 
     case all
-    case list(countries: [Country])
+    case list(countryIds: [Country.CountryIdentifier])
 
     var stringValue: String {
         switch self {
         case .all:
             return "all"
-        case .list(let countries):
-            return countries.map { $0.identifier }.joined(separator: ",")
+        case .list(let identifiers):
+            return identifiers.joined(separator: ",")
         }
     }
 }

--- a/Sources/UNogsAPI/Requests/FilteredTitlesQuery/Query Components/Extensions/Genres+Defaultable.swift
+++ b/Sources/UNogsAPI/Requests/FilteredTitlesQuery/Query Components/Extensions/Genres+Defaultable.swift
@@ -7,6 +7,6 @@
 
 import Foundation
 
-extension Array: Defaultable where Element == Genre {
-    public static var `default`: [Genre] = []
+extension Array: Defaultable where Element == GenreResponse {
+    public static var `default`: [GenreResponse] = []
 }

--- a/Sources/UNogsAPI/Requests/FilteredTitlesQuery/Query Components/Extensions/Genres+QueryComponent.swift
+++ b/Sources/UNogsAPI/Requests/FilteredTitlesQuery/Query Components/Extensions/Genres+QueryComponent.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-extension Array: QueryComponent where Element == Genre {
+extension Array: QueryComponent where Element == GenreResponse {
     var stringValue: String {
         self.flatMap { $0.identifiers }
             .map { "\($0)" }

--- a/Sources/UNogsAPI/Responses/Country.swift
+++ b/Sources/UNogsAPI/Responses/Country.swift
@@ -8,9 +8,10 @@
 import Foundation
 
 public struct Country: Codable, Equatable, Identifiable {
+    public typealias CountryIdentifier = String
 
     public enum InformationIndex: Int, CaseIterable {
-        case identifier = 0
+        case id = 0
         case shortCode
         case name
         case newTitles
@@ -25,9 +26,8 @@ public struct Country: Codable, Equatable, Identifiable {
         case priceTier3
     }
 
-    public var id: String { return identifier }
+    public let id: CountryIdentifier
     public let values: [String]
-    public let identifier: String
     public let shortCode: String
     public let name: String
     public let newTitles: Int
@@ -41,7 +41,7 @@ public struct Country: Codable, Equatable, Identifiable {
     public let priceTier3: String
 
     public init(values: [String],
-                identifier: String,
+                id: String,
                 shortCode: String,
                 name: String,
                 newTitles: Int,
@@ -54,7 +54,7 @@ public struct Country: Codable, Equatable, Identifiable {
                 priceTier2: String,
                 priceTier3: String) {
         self.values = values
-        self.identifier = identifier
+        self.id = id
         self.shortCode = shortCode
         self.name = name
         self.newTitles = newTitles
@@ -74,7 +74,7 @@ public struct Country: Codable, Equatable, Identifiable {
         guard values.count == InformationIndex.allCases.count else {
             throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unexpected number of values")
         }
-        identifier = values[.identifier]
+        id = values[.id]
         shortCode = values[.shortCode]
         name = values[.name]
         newTitles = try values[.newTitles].toInt()

--- a/Sources/UNogsAPI/Responses/CountryResponse.swift
+++ b/Sources/UNogsAPI/Responses/CountryResponse.swift
@@ -1,5 +1,5 @@
 //
-//  Country.swift
+//  CountryResponse.swift
 //  UNogsAPI
 //
 //  Created by Brian Murphy on 07/02/2020.
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Country: Codable, Equatable, Identifiable {
+public struct CountryResponse: Codable, Equatable, Identifiable {
     public typealias CountryIdentifier = String
 
     public enum InformationIndex: Int, CaseIterable {
@@ -95,7 +95,7 @@ public struct Country: Codable, Equatable, Identifiable {
 }
 
 private extension Array where Element == String {
-    subscript(_ index: Country.InformationIndex) -> String {
+    subscript(_ index: CountryResponse.InformationIndex) -> String {
         return self[index.rawValue]
     }
 }

--- a/Sources/UNogsAPI/Responses/GenreResponse.swift
+++ b/Sources/UNogsAPI/Responses/GenreResponse.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct Genre: Codable, Equatable {
+public struct GenreResponse: Codable, Equatable {
     public enum DecodingError: Error {
         case noData
     }
@@ -32,7 +32,7 @@ public struct Genre: Codable, Equatable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: GenreCodingKey.self)
         guard let key = container.allKeys.first else {
-            throw Genre.DecodingError.noData
+            throw GenreResponse.DecodingError.noData
         }
         name = key.stringValue
         identifiers = try container.decode([Int].self, forKey: key)

--- a/Sources/UNogsAPI/Responses/GenreResponse.swift
+++ b/Sources/UNogsAPI/Responses/GenreResponse.swift
@@ -8,14 +8,16 @@
 import Foundation
 
 public struct GenreResponse: Codable, Equatable {
+    public typealias GenreIdentifier = Int
+
     public enum DecodingError: Error {
         case noData
     }
 
     public let name: String
-    public let identifiers: [Int]
+    public let identifiers: [GenreIdentifier]
 
-    public init(name: String, identifiers: [Int]) {
+    public init(name: String, identifiers: [GenreIdentifier]) {
         self.name = name
         self.identifiers = identifiers
     }

--- a/Sources/UNogsAPI/Responses/TitleResponse.swift
+++ b/Sources/UNogsAPI/Responses/TitleResponse.swift
@@ -1,5 +1,5 @@
 //
-//  NetflixTitle.swift
+//  TitleResponse.swift
 //  UNogsAPITests
 //
 //  Created by Brian Murphy on 07/02/2020.
@@ -8,7 +8,7 @@
 import Foundation
 import Combine
 
-public struct NetflixTitle: Codable, Equatable, Identifiable {
+public struct TitleResponse: Codable, Equatable, Identifiable {
     public enum TitleType : String, Codable {
         case series
         case movie

--- a/Sources/UNogsAPI/Responses/TitleResponse.swift
+++ b/Sources/UNogsAPI/Responses/TitleResponse.swift
@@ -9,29 +9,9 @@ import Foundation
 import Combine
 
 public struct TitleResponse: Codable, Equatable, Identifiable {
-    public enum TitleType : String, Codable {
-        case series
-        case movie
+    public typealias TitleIdentifier = String
 
-        public init(from decoder: Decoder) throws {
-            // The API is unreliable and have seen instances of Movies and movie being returned so we must massage the data
-            let container = try decoder.singleValueContainer()
-            let string = try decoder.singleValueContainer().decode(String.self)
-            let lowerCasedString = string.lowercased()
-            guard let type = TitleType(rawValue: lowerCasedString) else {
-                throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unknown TitleType: \(string)")
-            }
-            self = type
-        }
-
-        public func encode(to encoder: Encoder) throws {
-            var container = encoder.singleValueContainer()
-            try container.encode(self.rawValue)
-        }
-    }
-
-    public var id: String { return netflixid }
-    public let netflixid: String
+    public var id: TitleIdentifier
     public let title: String
     public let image: String
     public let synopsis: String
@@ -41,7 +21,7 @@ public struct TitleResponse: Codable, Equatable, Identifiable {
     public let runtime: String
     public let unogsdate: String
 
-    public init(netflixid: String,
+    public init(id: String,
                 title: String,
                 image: String,
                 synopsis: String,
@@ -50,7 +30,7 @@ public struct TitleResponse: Codable, Equatable, Identifiable {
                 released: String,
                 runtime: String,
                 unogsdate: String) {
-        self.netflixid = netflixid
+        self.id = id
         self.title = title
         self.image = image
         self.synopsis = synopsis
@@ -59,5 +39,17 @@ public struct TitleResponse: Codable, Equatable, Identifiable {
         self.released = released
         self.runtime = runtime
         self.unogsdate = unogsdate
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id = "netflixid"
+        case title
+        case image
+        case synopsis
+        case rating
+        case type
+        case released
+        case runtime
+        case unogsdate
     }
 }

--- a/Sources/UNogsAPI/Responses/TitleType.swift
+++ b/Sources/UNogsAPI/Responses/TitleType.swift
@@ -1,0 +1,29 @@
+//
+//  File.swift
+//  
+//
+//  Created by Brian Murphy on 24/03/2020.
+//
+
+import Foundation
+
+public enum TitleType : String, Codable {
+    case series
+    case movie
+
+    public init(from decoder: Decoder) throws {
+        // The API is unreliable and have seen instances of Movies and movie being returned so we must massage the data
+        let container = try decoder.singleValueContainer()
+        let string = try decoder.singleValueContainer().decode(String.self)
+        let lowerCasedString = string.lowercased()
+        guard let type = TitleType(rawValue: lowerCasedString) else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "Unknown TitleType: \(string)")
+        }
+        self = type
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(self.rawValue)
+    }
+}

--- a/Sources/UNogsAPI/Responses/TitleType.swift
+++ b/Sources/UNogsAPI/Responses/TitleType.swift
@@ -12,7 +12,7 @@ public enum TitleType : String, Codable {
     case movie
 
     public init(from decoder: Decoder) throws {
-        // The API is unreliable and have seen instances of Movies and movie being returned so we must massage the data
+        // The API is unreliable and have seen instances of "Movie" and "movie" being returned so we must massage the data
         let container = try decoder.singleValueContainer()
         let string = try decoder.singleValueContainer().decode(String.self)
         let lowerCasedString = string.lowercased()

--- a/Tests/UNogsAPITests/FilteredTitlesQueryTests.swift
+++ b/Tests/UNogsAPITests/FilteredTitlesQueryTests.swift
@@ -48,7 +48,7 @@ class FilteredTitlesQueryTests: XCTestCase {
     }
 
     func testGenres() {
-        let genre = Genre(name: "Action", identifiers: [1,2,3])
+        let genre = GenreResponse(name: "Action", identifiers: [1,2,3])
         XCTAssertEqual(FilteredTitlesQuery(genres: []).queryString, "-!1990,2020-!0,5-!0,10-!-!Any-!Any-!Any-!gt1-!")
         XCTAssertEqual(FilteredTitlesQuery(genres: [genre]).queryString, "-!1990,2020-!0,5-!0,10-!1,2,3-!Any-!Any-!Any-!gt1-!")
     }

--- a/Tests/UNogsAPITests/FilteredTitlesQueryTests.swift
+++ b/Tests/UNogsAPITests/FilteredTitlesQueryTests.swift
@@ -79,8 +79,7 @@ class FilteredTitlesQueryTests: XCTestCase {
     func testCountriesList() {
         XCTAssertEqual(FilteredTitlesQuery().countriesFilter.stringValue, "all")
         XCTAssertEqual(FilteredTitlesQuery(countriesFilter: .all).countriesFilter.stringValue, "all")
-        XCTAssertEqual(FilteredTitlesQuery(countriesFilter: .list(countries: [.mock(identifier: "1"),
-                                                                              .mock(identifier: "2")])).countriesFilter.stringValue, "1,2")
+        XCTAssertEqual(FilteredTitlesQuery(countriesFilter: .list(countryIds: ["1", "2"])).countriesFilter.stringValue, "1,2")
     }
 
 }

--- a/Tests/UNogsAPITests/Mocks/Country+Mock.swift
+++ b/Tests/UNogsAPITests/Mocks/Country+Mock.swift
@@ -10,7 +10,7 @@ import UNogsAPI
 
 extension Country {
     static func mock(values: [String] = [],
-                     identifier: String = UUID().uuidString,
+                     id: String = UUID().uuidString,
                      shortCode: String = UUID().uuidString,
                      name: String = UUID().uuidString,
                      newTitles: Int = 1,
@@ -23,7 +23,7 @@ extension Country {
                      priceTier2: String = "2.99",
                      priceTier3: String = "3.99") -> Country {
         Country(values: values,
-                identifier: identifier,
+                id: id,
                 shortCode: shortCode,
                 name: name,
                 newTitles: newTitles,

--- a/Tests/UNogsAPITests/Mocks/Country+Mock.swift
+++ b/Tests/UNogsAPITests/Mocks/Country+Mock.swift
@@ -8,7 +8,7 @@
 import Foundation
 import UNogsAPI
 
-extension Country {
+extension CountryResponse {
     static func mock(values: [String] = [],
                      id: String = UUID().uuidString,
                      shortCode: String = UUID().uuidString,
@@ -21,8 +21,8 @@ extension Country {
                      currency: String = "GBP",
                      priceTier1: String = "1.99",
                      priceTier2: String = "2.99",
-                     priceTier3: String = "3.99") -> Country {
-        Country(values: values,
+                     priceTier3: String = "3.99") -> CountryResponse {
+        CountryResponse(values: values,
                 id: id,
                 shortCode: shortCode,
                 name: name,
@@ -37,6 +37,6 @@ extension Country {
                 priceTier3: priceTier3)
     }
 
-    static let gb = Country.mock(shortCode: "GB")
-    static let us = Country.mock(shortCode: "US")
+    static let gb = CountryResponse.mock(shortCode: "GB")
+    static let us = CountryResponse.mock(shortCode: "US")
 }

--- a/Tests/UNogsAPITests/Model Tests/CountryTests.swift
+++ b/Tests/UNogsAPITests/Model Tests/CountryTests.swift
@@ -13,7 +13,7 @@ import Combine
 final class CountryTests: CodableConformanceTest {
 
     func testPublicInit() throws {
-        let country = Country(values: [],
+        let country = CountryResponse(values: [],
                               id: "identifier",
                               shortCode: "shortCode",
                               name: "name",
@@ -44,14 +44,14 @@ final class CountryTests: CodableConformanceTest {
 
     func testCodableConformance() throws {
         let data = try JSONFileReader.shared.jsonData(from: "countries.json")
-        let countryResponse = try JSONDecoder().decode(ItemsResponse<Country>.self, from: data)
+        let countryResponse = try JSONDecoder().decode(ItemsResponse<CountryResponse>.self, from: data)
         try assertCodableConformance(of: countryResponse)
     }
 
     func testDecodingFailsIfIncorrectNumberOfProperties() throws {
         do {
             let data = try JSONFileReader.shared.jsonData(from: "countries_incorrect_elements.json")
-            _ = try JSONDecoder().decode(Country.self, from: data)
+            _ = try JSONDecoder().decode(CountryResponse.self, from: data)
             XCTFail()
         } catch {
             XCTAssertTrue(error is DecodingError)
@@ -61,7 +61,7 @@ final class CountryTests: CodableConformanceTest {
     func testDecodingFailsIfIntPropertiesCannotBeParsed() throws {
         do {
             let data = try JSONFileReader.shared.jsonData(from: "countries_unable_to_parse_ints.json")
-            _ = try JSONDecoder().decode(Country.self, from: data)
+            _ = try JSONDecoder().decode(CountryResponse.self, from: data)
             XCTFail()
         } catch {
             XCTAssertTrue(error is String.ParsingError)

--- a/Tests/UNogsAPITests/Model Tests/CountryTests.swift
+++ b/Tests/UNogsAPITests/Model Tests/CountryTests.swift
@@ -14,7 +14,7 @@ final class CountryTests: CodableConformanceTest {
 
     func testPublicInit() throws {
         let country = Country(values: [],
-                              identifier: "identifier",
+                              id: "identifier",
                               shortCode: "shortCode",
                               name: "name",
                               newTitles: 0,
@@ -28,7 +28,7 @@ final class CountryTests: CodableConformanceTest {
                               priceTier3: "priceTier3")
         XCTAssertNotNil(country)
         XCTAssertEqual(country.values, [])
-        XCTAssertEqual(country.identifier, "identifier")
+        XCTAssertEqual(country.id, "identifier")
         XCTAssertEqual(country.shortCode, "shortCode")
         XCTAssertEqual(country.name, "name")
         XCTAssertEqual(country.newTitles, 0)

--- a/Tests/UNogsAPITests/Model Tests/GenreTests.swift
+++ b/Tests/UNogsAPITests/Model Tests/GenreTests.swift
@@ -13,27 +13,27 @@ import Combine
 final class GenreTests: CodableConformanceTest {
 
     func testPublicInit() throws {
-        let genre = Genre(name: "Example", identifiers: [1,2,3])
+        let genre = GenreResponse(name: "Example", identifiers: [1,2,3])
         XCTAssertNotNil(genre)
     }
 
     func testInitializingCodingKeyWithIntValueReturnsNil() {
-        XCTAssertNil(Genre.GenreCodingKey(intValue: 0))
+        XCTAssertNil(GenreResponse.GenreCodingKey(intValue: 0))
     }
 
     func testCodableConformance() throws {
         let data = try JSONFileReader.shared.jsonData(from: "genres_response.json")
-        let genreResponse = try JSONDecoder().decode(ItemsResponse<Genre>.self, from: data)
+        let genreResponse = try JSONDecoder().decode(ItemsResponse<GenreResponse>.self, from: data)
         try assertCodableConformance(of: genreResponse)
     }
 
     func testDecodingFailsIfNoKeysArePresent() throws {
         do {
             let data = try JSONFileReader.shared.jsonData(from: "empty_genre_response.json")
-            _ = try JSONDecoder().decode(Genre.self, from: data)
+            _ = try JSONDecoder().decode(GenreResponse.self, from: data)
             XCTFail()
         } catch {
-            XCTAssertTrue(error is Genre.DecodingError)
+            XCTAssertTrue(error is GenreResponse.DecodingError)
         }
     }
 

--- a/Tests/UNogsAPITests/Model Tests/ItemsResponseTests.swift
+++ b/Tests/UNogsAPITests/Model Tests/ItemsResponseTests.swift
@@ -14,7 +14,7 @@ final class ItemsResponseTests: CodableConformanceTest {
 
     func testPublicInit() throws {
         let item = ItemsResponse(count: "10", objects: [
-            NetflixTitle(netflixid: "netflixid",
+            TitleResponse(netflixid: "netflixid",
                          title: "title",
                          image: "image",
                          synopsis: "synopsis",

--- a/Tests/UNogsAPITests/Model Tests/ItemsResponseTests.swift
+++ b/Tests/UNogsAPITests/Model Tests/ItemsResponseTests.swift
@@ -14,18 +14,18 @@ final class ItemsResponseTests: CodableConformanceTest {
 
     func testPublicInit() throws {
         let item = ItemsResponse(count: "10", objects: [
-            TitleResponse(netflixid: "netflixid",
-                         title: "title",
-                         image: "image",
-                         synopsis: "synopsis",
-                         rating: "rating",
-                         type: .movie,
-                         released: "released",
-                         runtime: "runtime",
-                         unogsdate: "unogsdate")
+            TitleResponse(id: "netflixid",
+                          title: "title",
+                          image: "image",
+                          synopsis: "synopsis",
+                          rating: "rating",
+                          type: .movie,
+                          released: "released",
+                          runtime: "runtime",
+                          unogsdate: "unogsdate")
         ])
         XCTAssertNotNil(item)
-        XCTAssertEqual(item.objects.first?.netflixid, "netflixid")
+        XCTAssertEqual(item.objects.first?.id, "netflixid")
         XCTAssertEqual(item.objects.first?.title, "title")
         XCTAssertEqual(item.objects.first?.image, "image")
         XCTAssertEqual(item.objects.first?.synopsis, "synopsis")

--- a/Tests/UNogsAPITests/Model Tests/NetflixTitleTests.swift
+++ b/Tests/UNogsAPITests/Model Tests/NetflixTitleTests.swift
@@ -13,15 +13,15 @@ import Combine
 final class NetflixTitleTests: CodableConformanceTest {
 
     func testCodableConformanceOfNetflixTitle() throws {
-        let title = TitleResponse(netflixid: "123",
-                                 title: "Movie Title!",
-                                 image: "...",
-                                 synopsis: "...",
-                                 rating: "5",
-                                 type: .movie,
-                                 released: "Yesterday",
-                                 runtime: "123mins",
-                                 unogsdate: "2019-09")
+        let title = TitleResponse(id: "123",
+                                  title: "Movie Title!",
+                                  image: "...",
+                                  synopsis: "...",
+                                  rating: "5",
+                                  type: .movie,
+                                  released: "Yesterday",
+                                  runtime: "123mins",
+                                  unogsdate: "2019-09")
         try assertCodableConformance(of: title)
     }
 

--- a/Tests/UNogsAPITests/Model Tests/NetflixTitleTests.swift
+++ b/Tests/UNogsAPITests/Model Tests/NetflixTitleTests.swift
@@ -13,7 +13,7 @@ import Combine
 final class NetflixTitleTests: CodableConformanceTest {
 
     func testCodableConformanceOfNetflixTitle() throws {
-        let title = NetflixTitle(netflixid: "123",
+        let title = TitleResponse(netflixid: "123",
                                  title: "Movie Title!",
                                  image: "...",
                                  synopsis: "...",
@@ -29,7 +29,7 @@ final class NetflixTitleTests: CodableConformanceTest {
         let fileURL = try JSONFileReader.shared.jsonFile(named: "netflix_title_incorrect_title_type.json")
         let data = try Data(contentsOf: fileURL)
         do {
-            _ = try JSONDecoder().decode(NetflixTitle.self, from: data)
+            _ = try JSONDecoder().decode(TitleResponse.self, from: data)
             XCTFail()
         } catch {
             XCTAssertTrue(error is DecodingError)

--- a/Tests/UNogsAPITests/UNogsAPITests.swift
+++ b/Tests/UNogsAPITests/UNogsAPITests.swift
@@ -21,8 +21,8 @@ final class UNogsAPITests: XCTestCase {
             XCTAssertEqual(response.count, "34")
             XCTAssertEqual(response.objects.count, 34)
 
-            XCTAssertEqual(response.objects.first?.id, response.objects.first?.identifier)
-            XCTAssertEqual(response.objects.first?.identifier, "21")
+            XCTAssertEqual(response.objects.first?.id, response.objects.first?.id)
+            XCTAssertEqual(response.objects.first?.id, "21")
             XCTAssertEqual(response.objects.first?.shortCode, "ar")
             XCTAssertEqual(response.objects.first?.name, "Argentina ")
             XCTAssertEqual(response.objects.first?.newTitles, 15)

--- a/Tests/UNogsAPITests/UNogsAPITests.swift
+++ b/Tests/UNogsAPITests/UNogsAPITests.swift
@@ -43,7 +43,7 @@ final class UNogsAPITests: XCTestCase {
         assert(publisher: sut.newReleasesPublisher(countryShortCode: "GB")) { response in
             XCTAssertEqual(response.count, "36")
             XCTAssertEqual(response.objects.count, 36)
-            XCTAssertEqual(response.objects.first?.id, response.objects.first?.netflixid)
+            XCTAssertEqual(response.objects.first?.id, response.objects.first?.id)
         }
     }
 
@@ -53,7 +53,7 @@ final class UNogsAPITests: XCTestCase {
         assert(publisher: sut.expiringPublisher(countryShortCode: "US")) { response in
             XCTAssertEqual(response.count, "70")
             XCTAssertEqual(response.objects.count, 70)
-            XCTAssertEqual(response.objects.first?.id, response.objects.first?.netflixid)
+            XCTAssertEqual(response.objects.first?.id, response.objects.first?.id)
         }
     }
 
@@ -64,7 +64,7 @@ final class UNogsAPITests: XCTestCase {
         assert(publisher: sut.filteredTitlesPublisher(query: query)) { response in
             XCTAssertEqual(response.count, "11118")
             XCTAssertEqual(response.objects.count, 100)
-            XCTAssertEqual(response.objects.first?.id, response.objects.first?.netflixid)
+            XCTAssertEqual(response.objects.first?.id, response.objects.first?.id)
         }
     }
 
@@ -78,7 +78,7 @@ final class UNogsAPITests: XCTestCase {
         assert(publisher: sut.filteredTitlesPublisher(query: query)) { response in
             XCTAssertEqual(response.count, "11118")
             XCTAssertEqual(response.objects.count, 100)
-            XCTAssertEqual(response.objects.first?.id, response.objects.first?.netflixid)
+            XCTAssertEqual(response.objects.first?.id, response.objects.first?.id)
         }
     }
 

--- a/Tests/UNogsAPITests/UNogsAPITests.swift
+++ b/Tests/UNogsAPITests/UNogsAPITests.swift
@@ -69,7 +69,7 @@ final class UNogsAPITests: XCTestCase {
     }
 
     func testFilteredTitlesWith7DaysNewQuery() throws {
-        let genre = Genre(name: "Action", identifiers: [1,2,3])
+        let genre = GenreResponse(name: "Action", identifiers: [1,2,3])
         let query = FilteredTitlesQuery(queryType: .getNew(days: 7),
                                         genres: [genre])
 


### PR DESCRIPTION
- Response objects now have their `id` properties typealias
- All objects that are responses have the suffix `Response`
- CountryFilter no longer requires a full Country object. It is just a list of `CountryIdentifier`s